### PR TITLE
Configuration to read permission and list layouts from osmtracker dir

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,8 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="net.osmtracker.layoutsdesigner">
 
-   <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+    <!-- <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />-->
 
     <application
         android:allowBackup="true"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,9 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="net.osmtracker.layoutsdesigner">
 
+   <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+
     <application
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"

--- a/app/src/main/java/net/osmtracker/layoutsdesigner/OsmtrackerLayoutsDesigner.java
+++ b/app/src/main/java/net/osmtracker/layoutsdesigner/OsmtrackerLayoutsDesigner.java
@@ -1,0 +1,26 @@
+package net.osmtracker.layoutsdesigner;
+
+import android.Manifest;
+
+public class OsmtrackerLayoutsDesigner {
+
+    public static final class Preferences{
+        //TAG
+        public final static String TAG = OsmtrackerLayoutsDesigner.class.getPackage().getName();
+
+        //Codes request
+        public final static int READ_STORAGE_PERMISSION_REQUEST_CODE = 101;
+        public final static int WRITE_STORAGE_PERMISSION_REQUEST_CODE = 102;
+
+        //permissions name
+        public final static String READ_STORAGE_PERMISSION = Manifest.permission.READ_EXTERNAL_STORAGE;
+        public final static String WRITE_STORAGE_PERMISSION = Manifest.permission.WRITE_EXTERNAL_STORAGE;
+
+        //Default
+        public final static String VAL_STORAGE_DIR = "/osmtracker";
+        public static final String LAYOUTS_SUBDIR = "layouts";
+        public static final String LAYOUT_FILE_EXTENSION = ".xml";
+
+    }
+
+}

--- a/app/src/main/java/net/osmtracker/layoutsdesigner/activity/MainActivity.java
+++ b/app/src/main/java/net/osmtracker/layoutsdesigner/activity/MainActivity.java
@@ -1,9 +1,11 @@
 package net.osmtracker.layoutsdesigner.activity;
 
 import android.content.DialogInterface;
+import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.os.Bundle;
 import android.os.Environment;
+import android.provider.Settings;
 import android.support.annotation.NonNull;
 import android.support.design.widget.FloatingActionButton;
 import android.support.design.widget.NavigationView;
@@ -105,8 +107,10 @@ public class MainActivity extends AppCompatActivity
                                     @Override
                                     public void onClick(View view) {
                                         Log.i("Intent", "Opening the app settings to grant the permission of read storage");
+                                        startActivity(new Intent(Settings.ACTION_APPLICATION_SETTINGS));
                                     }
                                 });
+                        snackbar.show();
                     }
                 });
 

--- a/app/src/main/java/net/osmtracker/layoutsdesigner/activity/MainActivity.java
+++ b/app/src/main/java/net/osmtracker/layoutsdesigner/activity/MainActivity.java
@@ -1,51 +1,56 @@
 package net.osmtracker.layoutsdesigner.activity;
 
-import android.Manifest;
+import android.content.DialogInterface;
 import android.content.pm.PackageManager;
 import android.os.Bundle;
-import android.os.Debug;
+import android.os.Environment;
 import android.support.annotation.NonNull;
 import android.support.design.widget.FloatingActionButton;
-import android.support.design.widget.Snackbar;
-import android.support.v4.app.ActivityCompat;
-import android.support.v4.content.ContextCompat;
-import android.util.Log;
-import android.view.View;
 import android.support.design.widget.NavigationView;
+import android.support.design.widget.Snackbar;
 import android.support.v4.view.GravityCompat;
 import android.support.v4.widget.DrawerLayout;
 import android.support.v7.app.ActionBarDrawerToggle;
+import android.support.v7.app.AlertDialog;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.Toolbar;
+import android.util.Log;
 import android.view.Menu;
 import android.view.MenuItem;
+import android.view.View;
 import android.widget.AdapterView;
 import android.widget.ListView;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import net.osmtracker.layoutsdesigner.OsmtrackerLayoutsDesigner;
 import net.osmtracker.layoutsdesigner.R;
+import net.osmtracker.layoutsdesigner.utils.CheckPermissions;
 import net.osmtracker.layoutsdesigner.utils.CustomAdapterListMain;
+import net.osmtracker.layoutsdesigner.utils.CustomLayoutsUtils;
 import net.osmtracker.layoutsdesigner.utils.ItemListMain;
 
+import java.io.File;
+import java.io.FilenameFilter;
 import java.util.ArrayList;
 
 public class MainActivity extends AppCompatActivity
         implements NavigationView.OnNavigationItemSelectedListener {
 
-    private ListView listLayoutContainer;
     private ArrayList<ItemListMain> itemsMainArray;
-    private static final int READ_PERMISSION_REQUEST = 001;
-    FloatingActionButton fab;
-
-    //This lists are only for test
-    private String[] names = new String[]{"Item 1", "Item 2", "Item 3"};
-    private String[] descriptions = new String[]{"Description 1", "Description 2", "Description 3"};
+    private FloatingActionButton fab;
+    private String contextTAG = OsmtrackerLayoutsDesigner.Preferences.TAG + ".MainActivity";
+    private String storageDir;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
+        setUpElemets();
+    }
+
+    //This mehtod is used to initialize the first elements in the screen
+    private void setUpElemets(){
         Toolbar toolbar = (Toolbar) findViewById(R.id.toolbar);
         setSupportActionBar(toolbar);
 
@@ -66,66 +71,121 @@ public class MainActivity extends AppCompatActivity
 
         NavigationView navigationView = (NavigationView) findViewById(R.id.nav_view);
         navigationView.setNavigationItemSelectedListener(this);
+        storageDir = File.separator + OsmtrackerLayoutsDesigner.Preferences.VAL_STORAGE_DIR;
+    }
 
-        //verify if the permissions of READ and WRITE DATA to storage are granted
-        int readPermissionCheck = ContextCompat.checkSelfPermission(MainActivity.this, Manifest.permission.READ_EXTERNAL_STORAGE);
-        if(readPermissionCheck != PackageManager.PERMISSION_GRANTED){
-            if(ActivityCompat.shouldShowRequestPermissionRationale(MainActivity.this, Manifest.permission.READ_EXTERNAL_STORAGE)){
-                // Show an expanation to the user *asynchronously* -- don't block
-                // this thread waiting for the user's response! After the user
-                // sees the explanation, try again to request the permission.
-                Toast.makeText(this, getResources().getString(R.string.permission_read_storage_needed), Toast.LENGTH_SHORT).show();
-                Snackbar snackbar = Snackbar.make(fab, getResources().getString(R.string.permission_read_storage_denied), Snackbar.LENGTH_LONG)
-                        .setAction(getResources().getString(R.string.snackbar_permission_request_denied_action), new View.OnClickListener() {
-                            @Override
-                            public void onClick(View v) {
-                                Log.i("Intent", "Opening the app settings to grant the permission of read storage");
-                            }
-                        });
-                snackbar.show();
+    @Override
+    protected void onResume() {
+        super.onResume();
+        //verify if the permission to READ storage are granted
+        if(CheckPermissions.isPermissionDenied(MainActivity.this, OsmtrackerLayoutsDesigner.Preferences.READ_STORAGE_PERMISSION)){
+
+            Log.i(contextTAG, "Permission to read storage denied");
+
+            //if the permission was denied by the user we push a dialog with a explanation message
+            if(CheckPermissions.needsToExplainToUser(MainActivity.this, OsmtrackerLayoutsDesigner.Preferences.READ_STORAGE_PERMISSION)){
+
+                AlertDialog.Builder builder = new AlertDialog.Builder(MainActivity.this);
+                builder.setMessage(getResources().getString(R.string.permission_read_storage_needed))
+                        .setTitle(getResources().getString(R.string.permission_request_dialog_tittle));
+
+                builder.setPositiveButton(getResources().getString(R.string.dialog_accept), new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialogInterface, int i) {
+                        Log.i(contextTAG, "User accept the message");
+                        CheckPermissions.makePermissionRequest(MainActivity.this, OsmtrackerLayoutsDesigner.Preferences.READ_STORAGE_PERMISSION,
+                                OsmtrackerLayoutsDesigner.Preferences.READ_STORAGE_PERMISSION_REQUEST_CODE);
+                    }
+                }).setNegativeButton(getResources().getString(R.string.dialog_cancel), new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialogInterface, int i) {
+                        Log.i(contextTAG, "User declined to accept the permission");
+                        Snackbar snackbar = Snackbar.make(fab, getResources().getString(R.string.permission_grant_settings), Snackbar.LENGTH_LONG)
+                                .setAction(getResources().getString(R.string.snackbar_permission_request_denied_action), new View.OnClickListener() {
+                                    @Override
+                                    public void onClick(View view) {
+                                        Log.i("Intent", "Opening the app settings to grant the permission of read storage");
+                                    }
+                                });
+                    }
+                });
+
+                AlertDialog dialog = builder.create();
+                dialog.show();
             }
             else{
-                // No explanation needed, we can request the permission.
-                ActivityCompat.requestPermissions(MainActivity.this, new String[]{Manifest.permission.READ_EXTERNAL_STORAGE}, READ_PERMISSION_REQUEST);
+                //We don't need to explain
+                CheckPermissions.makePermissionRequest(MainActivity.this, OsmtrackerLayoutsDesigner.Preferences.READ_STORAGE_PERMISSION,
+                        OsmtrackerLayoutsDesigner.Preferences.READ_STORAGE_PERMISSION_REQUEST_CODE);
             }
+        }
+        else{
+            //the permission is already granted
+            refreshActivity();
         }
     }
 
     @Override
     public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
-        switch (requestCode){
-            case READ_PERMISSION_REQUEST: {
-                // If request is cancelled, the result arrays are empty.
-                if(grantResults.length > 0 && grantResults[0] == PackageManager.PERMISSION_GRANTED){
-                    //TODO: makes the method to read the layouts from the directory of OSMTracker
-                    listLayoutContainer = (ListView) findViewById(R.id.list_layouts);
-                    itemsMainArray = new ArrayList<ItemListMain>();
-
-                    //TODO: changes this for the populate of the existing layouts
-                    for(int i = 0; i < names.length; i++){
-                        itemsMainArray.add(new ItemListMain(names[i], descriptions[i]));
-                    }
-
-                    //when the layouts are populated then inflate the list with the elements in the array
-                    if(itemsMainArray.size() > 0){
-                        TextView emptyTextView = (TextView) findViewById(R.id.empty_list);
-                        emptyTextView.setVisibility(View.INVISIBLE);
-                        CustomAdapterListMain adapterListMain = new CustomAdapterListMain(this, itemsMainArray);
-                        listLayoutContainer.setAdapter(adapterListMain);
-                        listLayoutContainer.setOnItemClickListener(new AdapterView.OnItemClickListener() {
-                            @Override
-                            public void onItemClick(AdapterView<?> adapterView, View view, int i, long l) {
-                                //TODO: replace with the functionality to show the info of the layout pressed
-                                Toast.makeText(MainActivity.this, "You press the item: " + itemsMainArray.get(i).getLayoutCreatedName(), Toast.LENGTH_LONG).show();
-                            }
-                        });
-                    }
+        switch (requestCode) {
+            case OsmtrackerLayoutsDesigner.Preferences.READ_STORAGE_PERMISSION_REQUEST_CODE: {
+                if (grantResults.length == 0 || grantResults[0] != PackageManager.PERMISSION_GRANTED) {
+                    Log.i(contextTAG, "The permission to read was denied by the user");
+                    Snackbar.make(fab, getResources().getString(R.string.permission_read_storage_denied), Snackbar.LENGTH_LONG).show();
                 }
                 else{
-                    //TODO: show a message to the user to notify that the permisson was denied and the app can't read the layouts that was already created
-                    Toast.makeText(this, getResources().getString(R.string.permission_read_storage_needed), Toast.LENGTH_SHORT).show();
-                    ActivityCompat.requestPermissions(MainActivity.this, new String[]{Manifest.permission.READ_EXTERNAL_STORAGE}, READ_PERMISSION_REQUEST);
+                    Log.i(contextTAG, "The permission to read was granted");
+                    refreshActivity();
                 }
+            }
+        }
+    }
+
+    //Use this method to refresh the MainActivity when a new layouts is created or downloaded from the OSMTracker App
+    private void refreshActivity(){
+        Toast.makeText(getApplicationContext(), "Preparing the layouts", Toast.LENGTH_SHORT).show();
+        ListView listLayoutContainer = (ListView) findViewById(R.id.list_layouts);
+        listLayouts(listLayoutContainer);
+    }
+
+    //This method search the layouts downloaded in the /osmtracker/layouts/ directory and show their as a list in the main screen
+    private void listLayouts(ListView container){
+        //we need to search the layouts in the path /osmtracker/layouts/
+        File layoutsDir = new File(Environment.getExternalStorageDirectory(),
+                storageDir + File.separator + OsmtrackerLayoutsDesigner.Preferences.LAYOUTS_SUBDIR + File.separator);
+
+        //verify if we can access to this path
+        if(layoutsDir.exists() && layoutsDir.canRead()){
+            //enlist all the xml files in this directory
+            String[] layoutFiles = layoutsDir.list(new FilenameFilter() {
+                @Override
+                public boolean accept(File dir, String fileName) {
+                    return fileName.endsWith(OsmtrackerLayoutsDesigner.Preferences.LAYOUT_FILE_EXTENSION);
+                }
+            });
+
+            //fill the array with the layouts founded
+            itemsMainArray = new ArrayList<ItemListMain>();
+            for(String fileName :  layoutFiles){
+                itemsMainArray.add(new ItemListMain(CustomLayoutsUtils.convertFileName(fileName), ""));
+            }
+            //verify if there are some layouts in the list to hide the message of "you don't have layouts yet"
+            if(itemsMainArray.size() > 0){
+                TextView emptyMessage = (TextView) findViewById(R.id.empty_list);
+                emptyMessage.setVisibility(View.INVISIBLE);
+                CustomAdapterListMain adapterListMain = new CustomAdapterListMain(MainActivity.this, itemsMainArray);
+                container.setAdapter(adapterListMain);
+                container.setOnItemClickListener(new AdapterView.OnItemClickListener() {
+                    @Override
+                    public void onItemClick(AdapterView<?> adapterView, View view, int i, long l) {
+                        Toast.makeText(MainActivity.this, "You press " + itemsMainArray.get(i).getLayoutCreatedName(),
+                                Toast.LENGTH_SHORT).show();
+                    }
+                });
+            }
+            else{
+                TextView emptyMessage = (TextView) findViewById(R.id.empty_list);
+                emptyMessage.setVisibility(View.VISIBLE);
             }
         }
     }

--- a/app/src/main/java/net/osmtracker/layoutsdesigner/activity/MainActivity.java
+++ b/app/src/main/java/net/osmtracker/layoutsdesigner/activity/MainActivity.java
@@ -1,8 +1,15 @@
 package net.osmtracker.layoutsdesigner.activity;
 
+import android.Manifest;
+import android.content.pm.PackageManager;
 import android.os.Bundle;
+import android.os.Debug;
+import android.support.annotation.NonNull;
 import android.support.design.widget.FloatingActionButton;
 import android.support.design.widget.Snackbar;
+import android.support.v4.app.ActivityCompat;
+import android.support.v4.content.ContextCompat;
+import android.util.Log;
 import android.view.View;
 import android.support.design.widget.NavigationView;
 import android.support.v4.view.GravityCompat;
@@ -28,6 +35,8 @@ public class MainActivity extends AppCompatActivity
 
     private ListView listLayoutContainer;
     private ArrayList<ItemListMain> itemsMainArray;
+    private static final int READ_PERMISSION_REQUEST = 001;
+    FloatingActionButton fab;
 
     //This lists are only for test
     private String[] names = new String[]{"Item 1", "Item 2", "Item 3"};
@@ -40,7 +49,7 @@ public class MainActivity extends AppCompatActivity
         Toolbar toolbar = (Toolbar) findViewById(R.id.toolbar);
         setSupportActionBar(toolbar);
 
-        FloatingActionButton fab = (FloatingActionButton) findViewById(R.id.fab_create_new_layout);
+        fab = (FloatingActionButton) findViewById(R.id.fab_create_new_layout);
         fab.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
@@ -58,27 +67,66 @@ public class MainActivity extends AppCompatActivity
         NavigationView navigationView = (NavigationView) findViewById(R.id.nav_view);
         navigationView.setNavigationItemSelectedListener(this);
 
-        listLayoutContainer = (ListView) findViewById(R.id.list_layouts);
-        itemsMainArray = new ArrayList<ItemListMain>();
-
-        //TODO: changes this for the populate of the existing layouts
-        for(int i = 0; i < names.length; i++){
-            itemsMainArray.add(new ItemListMain(names[i], descriptions[i]));
+        //verify if the permissions of READ and WRITE DATA to storage are granted
+        int readPermissionCheck = ContextCompat.checkSelfPermission(MainActivity.this, Manifest.permission.READ_EXTERNAL_STORAGE);
+        if(readPermissionCheck != PackageManager.PERMISSION_GRANTED){
+            if(ActivityCompat.shouldShowRequestPermissionRationale(MainActivity.this, Manifest.permission.READ_EXTERNAL_STORAGE)){
+                // Show an expanation to the user *asynchronously* -- don't block
+                // this thread waiting for the user's response! After the user
+                // sees the explanation, try again to request the permission.
+                Toast.makeText(this, getResources().getString(R.string.permission_read_storage_needed), Toast.LENGTH_SHORT).show();
+                Snackbar snackbar = Snackbar.make(fab, getResources().getString(R.string.permission_read_storage_denied), Snackbar.LENGTH_LONG)
+                        .setAction(getResources().getString(R.string.snackbar_permission_request_denied_action), new View.OnClickListener() {
+                            @Override
+                            public void onClick(View v) {
+                                Log.i("Intent", "Opening the app settings to grant the permission of read storage");
+                            }
+                        });
+                snackbar.show();
+            }
+            else{
+                // No explanation needed, we can request the permission.
+                ActivityCompat.requestPermissions(MainActivity.this, new String[]{Manifest.permission.READ_EXTERNAL_STORAGE}, READ_PERMISSION_REQUEST);
+            }
         }
+    }
 
-        //when the layouts are populated then inflate the list with the elements in the array
-        if(itemsMainArray.size() > 0){
-            TextView emptyTextView = (TextView) findViewById(R.id.empty_list);
-            emptyTextView.setVisibility(View.INVISIBLE);
-            CustomAdapterListMain adapterListMain = new CustomAdapterListMain(this, itemsMainArray);
-            listLayoutContainer.setAdapter(adapterListMain);
-            listLayoutContainer.setOnItemClickListener(new AdapterView.OnItemClickListener() {
-                @Override
-                public void onItemClick(AdapterView<?> adapterView, View view, int i, long l) {
-                    //TODO: replace with the functionality to show the info of the layout pressed
-                    Toast.makeText(MainActivity.this, "You press the item: " + itemsMainArray.get(i).getLayoutCreatedName(), Toast.LENGTH_SHORT).show();
+    @Override
+    public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
+        switch (requestCode){
+            case READ_PERMISSION_REQUEST: {
+                // If request is cancelled, the result arrays are empty.
+                if(grantResults.length > 0 && grantResults[0] == PackageManager.PERMISSION_GRANTED){
+                    //TODO: makes the method to read the layouts from the directory of OSMTracker
+                    listLayoutContainer = (ListView) findViewById(R.id.list_layouts);
+                    itemsMainArray = new ArrayList<ItemListMain>();
+
+                    //TODO: changes this for the populate of the existing layouts
+                    for(int i = 0; i < names.length; i++){
+                        itemsMainArray.add(new ItemListMain(names[i], descriptions[i]));
+                    }
+
+                    //when the layouts are populated then inflate the list with the elements in the array
+                    if(itemsMainArray.size() > 0){
+                        TextView emptyTextView = (TextView) findViewById(R.id.empty_list);
+                        emptyTextView.setVisibility(View.INVISIBLE);
+                        CustomAdapterListMain adapterListMain = new CustomAdapterListMain(this, itemsMainArray);
+                        listLayoutContainer.setAdapter(adapterListMain);
+                        listLayoutContainer.setOnItemClickListener(new AdapterView.OnItemClickListener() {
+                            @Override
+                            public void onItemClick(AdapterView<?> adapterView, View view, int i, long l) {
+                                //TODO: replace with the functionality to show the info of the layout pressed
+                                Toast.makeText(MainActivity.this, "You press the item: " + itemsMainArray.get(i).getLayoutCreatedName(), Toast.LENGTH_LONG).show();
+                            }
+                        });
+                    }
                 }
-            });
+                else{
+                    //TODO: show a message to the user to notify that the permisson was denied and the app can't read the layouts that was already created
+                    Toast.makeText(this, getResources().getString(R.string.permission_read_storage_needed), Toast.LENGTH_SHORT).show();
+                    ActivityCompat.requestPermissions(MainActivity.this, new String[]{Manifest.permission.READ_EXTERNAL_STORAGE}, READ_PERMISSION_REQUEST);
+                }
+            }
         }
     }
 

--- a/app/src/main/java/net/osmtracker/layoutsdesigner/utils/CheckPermissions.java
+++ b/app/src/main/java/net/osmtracker/layoutsdesigner/utils/CheckPermissions.java
@@ -1,0 +1,43 @@
+package net.osmtracker.layoutsdesigner.utils;
+
+import android.app.Activity;
+import android.content.Context;
+import android.content.pm.PackageManager;
+import android.support.v4.app.ActivityCompat;
+import android.support.v4.content.ContextCompat;
+import android.util.Log;
+
+public class CheckPermissions {
+
+    /**
+     * This method check if certain permission is denied or granted, and then returns the result (if is denied then the app needs to make the request)
+     * @param context = the current context where the permission is needed
+     * @param permissionToCheck = string with the permission to check (example: Manifest.permission.READ_EXTERNAL_STORAGE)
+     * @return true if the permission is denied or false if is granted
+     */
+    public static boolean isPermissionDenied(Context context, String permissionToCheck){
+        Log.i("CheckPermissions", "Verifying if the permission is denied");
+        return ContextCompat.checkSelfPermission(context, permissionToCheck) != PackageManager.PERMISSION_GRANTED;
+    }
+
+    /**
+     * This method check if we need to show a more explain dialog to user because he denied the permission
+     * @param activity = the current activity where the permission is needed
+     * @param permissionToCheck = string with the permission denied
+     * @return true if is needed make a better explanation or false is not
+     */
+    public static boolean needsToExplainToUser(Activity activity, String permissionToCheck){
+        Log.i("CheckPermissions", "Verifying if wee need a better explanation");
+        return ActivityCompat.shouldShowRequestPermissionRationale(activity, permissionToCheck);
+    }
+
+    /**
+     * This method makes a request with the specified permission and code request
+     * @param activity = the current activity where we need to make the request
+     * @param permissionToRequest = string with the permission to make the request
+     * @param REQUEST_PERMISSION_CODE = a integer number that act like an id to the current request
+     */
+    public static void makePermissionRequest(Activity activity, String permissionToRequest, int REQUEST_PERMISSION_CODE) {
+        ActivityCompat.requestPermissions(activity, new String[]{permissionToRequest}, REQUEST_PERMISSION_CODE);
+    }
+}

--- a/app/src/main/java/net/osmtracker/layoutsdesigner/utils/CustomLayoutsUtils.java
+++ b/app/src/main/java/net/osmtracker/layoutsdesigner/utils/CustomLayoutsUtils.java
@@ -1,0 +1,27 @@
+package net.osmtracker.layoutsdesigner.utils;
+
+import net.osmtracker.layoutsdesigner.OsmtrackerLayoutsDesigner;
+
+public class CustomLayoutsUtils {
+    //File Extension for the layouts in different languages
+    public final static String LAYOUT_EXTENSION_ISO = "_xx.xml";
+    public static final int ISO_CHARACTER_LENGTH = 2;
+
+    /**
+     * @param fileName is the name of a .xml that you want to convert to presentation name
+     * @return a String presentation name, if the type isn't valid returns the same fileName parameter
+     */
+    public static String convertFileName(String fileName) {
+        //Remove de file extension
+        String subname = fileName.replace(OsmtrackerLayoutsDesigner.Preferences.LAYOUT_FILE_EXTENSION,"");
+
+        //Check if it has iso:
+        if(subname.matches("\\w+_..")){
+            //Remove "_es"
+            subname = subname.substring(0,subname.length() - (ISO_CHARACTER_LENGTH+1));
+        }
+
+        //Replace "_" to " "
+        return subname.replace("_"," ");
+    }
+}

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -5,7 +5,6 @@
     android:id="@+id/drawer_layout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="@color/colorPrimaryLight"
     android:fitsSystemWindows="true"
     tools:openDrawer="start">
 

--- a/app/src/main/res/layout/app_bar_main.xml
+++ b/app/src/main/res/layout/app_bar_main.xml
@@ -4,7 +4,6 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="@color/colorPrimaryLight"
     tools:context=".activity.MainActivity">
 
     <android.support.design.widget.AppBarLayout

--- a/app/src/main/res/layout/content_main.xml
+++ b/app/src/main/res/layout/content_main.xml
@@ -5,6 +5,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     app:layout_behavior="@string/appbar_scrolling_view_behavior"
+    android:background="@color/colorPrimaryLight"
     tools:context=".activity.MainActivity"
     tools:showIn="@layout/app_bar_main">
 

--- a/app/src/main/res/layout/item_list_main.xml
+++ b/app/src/main/res/layout/item_list_main.xml
@@ -4,7 +4,6 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:background="@color/colorPrimaryLight"
     android:layout_height="wrap_content">
 
     <TextView

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -19,7 +19,11 @@
     <string name="snackbar_permission_request_denied_action">Settings</string>
 
     <!--Permissions requested-->
+    <string name="permission_request_dialog_tittle">Permission Required</string>
+    <string name="dialog_accept">Accept</string>
+    <string name="dialog_cancel">Cancel</string>
     <string name="permission_read_storage_needed">The permission to read storage is needed to show the current layouts installed</string>
-    <string name="permission_read_storage_denied">You can grant the permission in the app settings</string>
+    <string name="permission_read_storage_denied">You cannot see the layouts installed in your phone</string>
+    <string name="permission_grant_settings">You can grant this permission from app settings</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -16,4 +16,10 @@
     <!--Main Screen-->
     <string name="empty_list_layouts">You don\'t have layouts yet</string>
     <string name="menu_action_search">Search</string>
+    <string name="snackbar_permission_request_denied_action">Settings</string>
+
+    <!--Permissions requested-->
+    <string name="permission_read_storage_needed">The permission to read storage is needed to show the current layouts installed</string>
+    <string name="permission_read_storage_denied">You can grant the permission in the app settings</string>
+
 </resources>


### PR DESCRIPTION
With this PR I configured (also created) a way to manage the permissions in the app (in a separate class) following the android recommendations.

Also, I developed the functionality to read the layouts downloaded in the phone and display them on the main screen of the app, so when a user downloads a new layout it will also appear in the app (As well, when it is removed from the OSMTracker, in the app it will not be shown anymore)