### PR TITLE
Bug fixed: All the new Layouts and new Buttons must have names.

### DIFF
--- a/app/src/main/java/net/osmtracker/layoutsdesigner/activity/Editor.java
+++ b/app/src/main/java/net/osmtracker/layoutsdesigner/activity/Editor.java
@@ -350,39 +350,23 @@ public class Editor extends AppCompatActivity {
 
         final AlertDialog dialog = builder.create();
 
-
         buttonName.addTextChangedListener(new TextWatcher() {
             @Override
             public void beforeTextChanged(CharSequence charSequence, int i, int i1, int i2) {
-
             }
 
             @Override
             public void onTextChanged(CharSequence charSequence, int i, int i1, int i2) {
-                Button btOk = dialog.getButton(AlertDialog.BUTTON_POSITIVE);
-                if(charSequence.length() >=0) {
-                    try {
-
-                        if(charSequence.length() == 0){
-                            btOk.setEnabled(false);
-                        }
-                        else{
-                            btOk.setEnabled(true);
-                        }
-
-                    }catch (Exception e){
-                        Log.e(contextTag, "Error editing the button name");
-
-                    }
-                }
             }
 
             @Override
             public void afterTextChanged(Editable editable) {
-
+                if (buttonName.getText().toString().isEmpty()) dialog.getButton(android.support.v7.app.AlertDialog.BUTTON_POSITIVE).setEnabled(false);
+                else dialog.getButton(android.support.v7.app.AlertDialog.BUTTON_POSITIVE).setEnabled(true);
             }
         });
         dialog.show();
+        dialog.getButton(android.support.v7.app.AlertDialog.BUTTON_POSITIVE).setEnabled(false);
 
 
     }

--- a/app/src/main/java/net/osmtracker/layoutsdesigner/activity/MainActivity.java
+++ b/app/src/main/java/net/osmtracker/layoutsdesigner/activity/MainActivity.java
@@ -12,6 +12,8 @@ import android.support.annotation.NonNull;
 import android.support.design.widget.FloatingActionButton;
 import android.support.design.widget.Snackbar;
 import android.support.v7.widget.AppCompatSpinner;
+import android.text.Editable;
+import android.text.TextWatcher;
 import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -147,7 +149,7 @@ public class MainActivity extends AppCompatActivity
         final CheckBox cbxNotes = (CheckBox) popupLayout.findViewById(R.id.cbx_text_note);
         setSpinners(popupLayout);
 
-        AlertDialog.Builder builder = new AlertDialog.Builder(MainActivity.this, AlertDialog.THEME_DEVICE_DEFAULT_DARK);
+        final AlertDialog.Builder builder = new AlertDialog.Builder(MainActivity.this, AlertDialog.THEME_DEVICE_DEFAULT_DARK);
         builder.setTitle(R.string.preparing_pop_up_title)
                 .setView(popupLayout)
                 .setPositiveButton(R.string.dialog_accept, new DialogInterface.OnClickListener() {
@@ -171,8 +173,27 @@ public class MainActivity extends AppCompatActivity
                         dialogInterface.cancel();
                     }
                 })
-                .setCancelable(true)
-                .create().show();
+                .setCancelable(true);
+
+        final AlertDialog dialog = builder.create();
+
+        txtLayoutName.addTextChangedListener(new TextWatcher() {
+            @Override
+            public void beforeTextChanged(CharSequence charSequence, int i, int i1, int i2) {
+            }
+
+            @Override
+            public void onTextChanged(CharSequence charSequence, int i, int i1, int i2) {
+            }
+
+            @Override
+            public void afterTextChanged(Editable editable) {
+                if (txtLayoutName.getText().toString().isEmpty()) dialog.getButton(android.support.v7.app.AlertDialog.BUTTON_POSITIVE).setEnabled(false);
+                else dialog.getButton(android.support.v7.app.AlertDialog.BUTTON_POSITIVE).setEnabled(true);
+            }
+        });
+        dialog.show();
+        dialog.getButton(android.support.v7.app.AlertDialog.BUTTON_POSITIVE).setEnabled(false);
     }
 
     public void setSpinners(View v){

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -49,7 +49,7 @@
     <string name="succesfully_created_title">Layout created</string>
     <string name="succesfully_created_message">The layout was created successfully, now you can set it up in the OSMTracker application!</string>
     <string name="error_creating_message">Error creating the layout file</string>
-    <string name="some_empty_buttons">There are empty buttons</string>
+    <string name="some_empty_buttons">All buttons must be edited</string>
 
     <!--New button Pop Up-->
     <string name="new_button_pop_up_title">New Button</string>


### PR DESCRIPTION
The PossitiveButton in AlertDialogs on MainActivity and EditorActivity is enabled only if the user writes a name on the new **layout** or new **button** PopUp. 