### PR TITLE
Enable Accept button when user re-edit a button

### DIFF
--- a/app/src/main/java/net/osmtracker/layoutsdesigner/activity/Editor.java
+++ b/app/src/main/java/net/osmtracker/layoutsdesigner/activity/Editor.java
@@ -368,7 +368,8 @@ public class Editor extends AppCompatActivity {
             }
         });
         dialog.show();
-        dialog.getButton(android.support.v7.app.AlertDialog.BUTTON_POSITIVE).setEnabled(false);
+        if (buttonName.getText().toString().isEmpty()) dialog.getButton(android.support.v7.app.AlertDialog.BUTTON_POSITIVE).setEnabled(false);
+        else dialog.getButton(android.support.v7.app.AlertDialog.BUTTON_POSITIVE).setEnabled(true);
 
 
     }


### PR DESCRIPTION
Fix bug (in Editor Activity) when user re-edit a button in a new layout.
I enabled the Accept button after the alert dialog is shown and only if there are some text in the EditText View.